### PR TITLE
TOCメニューにタイトルが表示されない不具合修正

### DIFF
--- a/comistream/code/comistream_lib.php
+++ b/comistream/code/comistream_lib.php
@@ -1357,7 +1357,7 @@ function openPage()
     global $conf;
     global $tempDir, $cacheDir, $cacheSize, $sharePath, $publicDir, $md5cmd, $dbh,
         $page, $file, $baseFile, $maxPage, $user, $openFile, $escapedFile, $coverFile,
-        $previewFile, $existDir, $direction, $position, $degree, $fileSize, $averagePageBytes;
+        $previewFile, $existDir, $direction, $position, $degree, $fileSize, $averagePageBytes, $bookName ;
 
     // テンポラリ領域がなければ作成
     writelog("DEBUG openPage() tempDir:" . $tempDir);


### PR DESCRIPTION
- openPage() 関数のグローバル変数宣言に $bookName を追加
- 既存のグローバル変数リストに新しい変数を適切に統合